### PR TITLE
add missing fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,16 @@
   },
   "devDependencies": {
     "mocha": "^2.1.0"
-  }
+  },
+  "directories": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/18F/urlsize.git"
+  },
+  "bugs": {
+    "url": "https://github.com/18F/urlsize/issues"
+  },
+  "homepage": "https://github.com/18F/urlsize"
 }


### PR DESCRIPTION
I tried to use `npm-clone` with this but the repository field was missing, so I just ran `npm init` which adds missing fields (in this case repository + friends). 
