### PR TITLE
streaming support with --stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "CC0",
   "dependencies": {
     "async": "^0.9.0",
+    "event-stream": "^3.2.2",
     "fast-csv": "^0.5.6",
     "filesize": "^3.1.1",
     "request": "^2.53.0",


### PR DESCRIPTION
:construction: **WIP** :construction:

As suggested by @maxogden, this PR adds streaming support via the `--stream` option. If you run:

``` sh
urlsize --stream
```

Then type a URL and hit <kbd>return</kbd>, and it'll print the size. This isn't ready for merging yet. It needs:
- [ ] tests (see [the ones I wrote last night](https://github.com/18F/urlsize/blob/stream/test/index.js))
- [ ] compatibility with csv/tsv output

Max, I could use your help with the latter. I tried a couple of different things [here](https://github.com/18F/urlsize/blob/stream/index.js#L51-L66), namely:

``` js
var out = process.stdin
  .pipe(es.split())
  .pipe(es.map(getFileSize))
  .pipe(getCSVStream())
  .pipe(process.stdout);
```

But when I run `urlsize --stream --csv`, map-stream throws a `TypeError('invalid data')`. What am I doing wrong here?

Also, this will clearly cause conflicts with your [JS API PR](https://github.com/18F/urlsize/pull/2). I'll add some notes about this there, as I have some input on the API now that the code is starting to branch more distinctly in on the CLI side.
