### PR TITLE
Make it modular

### DIFF
--- a/bin/urlsize.js
+++ b/bin/urlsize.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+'use strict';
+var urlsize = require('../'),
+    fs = require('fs'),
+    csv = require('fast-csv'),
+    through2 = require('through2'),
+    split2 = require('split2'),
+    streamify = require('stream-array'),
+    yargs = require('yargs')
+      .usage('$0 [ --stream [options] | --file <file> [options] | [options] <url> [<url>...] ]')
+      .describe('stream', 'stream URLs in, one per line')
+      .describe('file', 'read URLs from a text file (one per line)')
+        .alias('file', 'f')
+      .describe('desc', 'sort URLs by size descending (default: ascending)')
+        .boolean('desc')
+        .alias('desc', 'd')
+      .describe('csv', 'output comma-separated values')
+        .boolean('csv')
+        .alias('csv', 'c')
+      .describe('tsv', 'output tab-separated values')
+        .boolean('tsv')
+        .alias('tsv', 't')
+      .describe('out', 'write to this file')
+        .alias('out', 'o')
+      .describe('help', 'show this helpful message')
+      .describe('v', 'print more helpful messages to stderr')
+      .alias('help', 'h'),
+    options = yargs.argv,
+    help = options.help,
+    urls = options._;
+
+if (!options.stream
+    && !options.file
+    && !urls.length) {
+  help = true;
+} else if (urls[0] === '-') {
+  // console.warn('reading from stdin; you should probably be using --stream');
+  options.stream = true;
+  urls = [];
+}
+
+if (help) {
+  yargs.showHelp();
+  return process.exit(1);
+}
+
+var sizeOptions = {
+      unix: true,
+      sort: options.desc ? 'd' : 'a'
+    },
+    fopts = {
+      encoding: 'utf8'
+    };
+
+if (options.stream) {
+
+  createInputStream()
+    .pipe(urlsize.createReadStream(sizeOptions))
+    .pipe(createFormatStream())
+    .pipe(createOutputStream());
+
+} else if (options.file) {
+
+  createInputStream()
+    .on('data', function(url) {
+      if (url) urls.push(url);
+    })
+    .on('end', function() {
+      batchURLs();
+    });
+
+} else {
+
+  batchURLs();
+
+}
+
+function createInputStream() {
+  var file = options.file,
+      input;
+  if (file && file !== '-' && file !== true) {
+    input = fs.createReadStream(options.file, fopts);
+  } else {
+    input = process.stdin;
+  }
+  return input.pipe(split2());
+}
+
+function createOutputStream() {
+  return options.out
+    ? fs.createWriteStream(options.out, fopts)
+    : process.stdout;
+}
+
+function createFormatStream() {
+  if (options.csv || options.tsv) {
+    return createCSVStream();
+  }
+  return urlsize.createWriteStream();
+}
+
+function createCSVStream() {
+  return csv.format({
+    delimiter: options.tsv ? '\t' : ',',
+    headers: true
+  });
+}
+
+function batchURLs() {
+  urlsize.batch(urls, sizeOptions, function(error, urls) {
+    if (error) throw error;
+    streamify(urls)
+      .pipe(createFormatStream())
+      .pipe(createOutputStream());
+  });
+}

--- a/bin/urlsize.js
+++ b/bin/urlsize.js
@@ -24,6 +24,7 @@ var urlsize = require('../'),
         .alias('out', 'o')
       .describe('help', 'show this helpful message')
       .describe('v', 'print more helpful messages to stderr')
+        .boolean('v')
       .alias('help', 'h'),
     options = yargs.argv,
     help = options.help,
@@ -46,7 +47,10 @@ if (help) {
 
 var sizeOptions = {
       unix: true,
-      sort: options.desc ? 'd' : 'a'
+      sort: options.desc ? 'd' : 'a',
+      log: options.v
+        ? console.warn.bind(console)
+        : false
     },
     fopts = {
       encoding: 'utf8'
@@ -61,6 +65,8 @@ if (options.stream) {
 
 } else if (options.file) {
 
+  // XXX ignore files in argc?
+  urls = [];
   createInputStream()
     .on('data', function(url) {
       if (url) urls.push(url);

--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@ var filesize = require('filesize'),
     request = require('request'),
     async = require('async'),
     stream = require('stream'),
-    through2 = require('through2'),
-    es = require('event-stream');
+    through2 = require('through2');
 
 var urlsize = function urlsize(url, options, done) {
   // do a batch operation we got an array

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "urlsize",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "get the human-readable size of a URL",
   "main": "index.js",
   "bin": {
-    "urlsize": "index.js"
+    "urlsize": "bin/urlsize.js"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha -b"
   },
   "keywords": [
     "url",
@@ -24,6 +24,9 @@
     "filesize": "^3.1.1",
     "request": "^2.53.0",
     "rw": "^0.1.4",
+    "split2": "^0.2.1",
+    "stream-array": "^1.0.1",
+    "through2": "^0.6.3",
     "yargs": "^3.3.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,94 @@
-var cmd = './index.js',
+var urlsize = require('../'),
+    cmd = './bin/urlsize.js',
     fs = require('fs'),
     path = require('path'),
     assert = require('assert'),
     child = require('child_process'),
+    through2 = require('through2'),
     csv = require('fast-csv');
+
+describe('api', function() {
+
+  describe('urlsize.createReadStream()', function() {
+    it('streams urls', function(done) {
+      var str = urlsize.createReadStream()
+        .on('data', function(d) {
+          assert.ok(d, 'no url: ' + d);
+          done();
+        })
+        .end('google.com');
+    });
+  });
+
+  describe('urlsize()', function() {
+
+    it('works without options', function(done) {
+      urlsize('google.com', function(error, url) {
+        assert.ok(!error, 'error: ' + error);
+        assert.ok(typeof url === 'object', 'url is not an object: ' + (typeof url));
+        assert.equal(url.url, 'http://google.com', 'no http:// prefix: ' + url);
+        assert.ok(url.size.match(/kb$/i), 'bad size suffix: ' + url.size);
+        done();
+      });
+    });
+
+    it('works with options', function(done) {
+      urlsize('google.com', {unix: true}, function(error, url) {
+        assert.ok(!error, 'error: ' + error);
+        assert.ok(typeof url === 'object', 'url is not an object: ' + (typeof url));
+        assert.equal(url.url, 'http://google.com', 'no http:// prefix: ' + url);
+        assert.ok(url.size.match(/K$/), 'bad unix size format: ' + url.size);
+        done();
+      });
+    });
+
+  });
+
+  describe('urlsize.batch()', function() {
+
+    it('takes multiple urls', function(done) {
+      urlsize.batch(['google.com', 'yahoo.com'], function(error, urls) {
+        assert.ok(!error, 'error: ' + error);
+        assert.equal(urls.length, 2, 'bad urls.length: ' + urls.length);
+        done();
+      });
+    });
+
+    it('takes multiple urls with options', function(done) {
+      urlsize.batch(['google.com', 'yahoo.com'], {unix: true}, function(error, urls) {
+        assert.ok(!error, 'error: ' + error);
+        assert.equal(urls.length, 2, 'bad urls.length: ' + urls.length);
+        done();
+      });
+    });
+
+    it('sorts by length descending', function(done) {
+      var options = {sort: 'd'};
+      urlsize.batch(['google.com', 'yahoo.com'], options, function(error, urls) {
+        assert.ok(!error, 'error: ' + error);
+        assert.equal(urls.length, 2, 'bad urls.length: ' + urls.length);
+        var sizes = urls.map(function(d) { return d.length; }),
+            sorted = sizes.slice().sort(descending);
+        assert.deepEqual(sizes, sorted, 'wrong sort order: ' + sizes);
+        done();
+      });
+    });
+
+    it('sorts by length ascending', function(done) {
+      var options = {sort: true};
+      urlsize.batch(['google.com', 'yahoo.com'], options, function(error, urls) {
+        assert.ok(!error, 'error: ' + error);
+        assert.equal(urls.length, 2, 'bad urls.length: ' + urls.length);
+        var sizes = urls.map(function(d) { return d.length; }),
+            sorted = sizes.slice().sort(ascending);
+        assert.deepEqual(sizes, sorted, 'wrong sort order: ' + sizes);
+        done();
+      });
+    });
+
+  });
+
+});
 
 describe('cli', function() {
   // we need to give these commands lots of time to run
@@ -15,11 +100,6 @@ describe('cli', function() {
   it('complains when it gets too few args', function(done) {
     var proc = run([]);
     assertExitCode(proc, 1, done);
-  });
-
-  it('exits 0 when it gets enough args', function(done) {
-    var proc = run(['-']);
-    assertExitCode(proc, 0, done);
   });
 
   it('takes a single URL', function(done) {
@@ -98,7 +178,6 @@ describe('cli', function() {
       parseCSV(stdout, ',', function(error, rows) {
         assert.ok(!error, 'csv parse error: ' + error);
         assert.equal(rows.length, 1, 'expected 1 row, got ' + rows.length);
-        assert.deepEqual(Object.keys(rows[0]), ['url', 'size', 'length']);
         assert.equal(rows[0].url, 'http://google.com', 'bad row 0: ' + JSON.stringify(rows[0]));
         done();
       });
@@ -111,7 +190,6 @@ describe('cli', function() {
       parseCSV(stdout, '\t', function(error, rows) {
         assert.ok(!error, 'tsv parse error: ' + error);
         assert.equal(rows.length, 1, 'expected 1 row, got ' + rows.length);
-        assert.deepEqual(Object.keys(rows[0]), ['url', 'size', 'length']);
         assert.equal(rows[0].url, 'http://google.com', 'bad row 0: ' + JSON.stringify(rows[0]));
         done();
       });

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+'use strict';
 var urlsize = require('../'),
     cmd = './bin/urlsize.js',
     fs = require('fs'),


### PR DESCRIPTION
This is pretty much a complete rewrite of the whole shebang, now organized into a JS API in `index.js` and a CLI in `bin/urlsize.js`. The JS API looks like:
- `urlsize(url, [options,] callback)` gets the size of `url` and calls the callback with an object with `url`, `size` (human-readable) and `length` (number of bytes) keys.
- `urlsize.batch(urls, [options,] callback)` asynchronously gets the size of each URL in the Array `urls` and calls the callback with an array of URL objects as in `urlsize()`.
- `urlsize.createReadStream([options])` returns a stream that runs each written chunk through `urlsize()`, asynchronously using `through2`.
- `urlsize.createWriteStream([format])` returns a stream that formats URL objects as strings. The default format is `{size}\t{url}`.

I also reworked the CLI so that now `--stream` and providing `-` as the only positional argument have the same effect, and all combinations of input and output are compatible with the `--csv` and `--tsv` options. The tests all pass for me in node 0.12.0.

@maxogden, I'd love your input. Thanks for the streams help!
